### PR TITLE
Make it compatible with bundler require

### DIFF
--- a/lib/rack/cloudflare/jwt.rb
+++ b/lib/rack/cloudflare/jwt.rb
@@ -1,0 +1,1 @@
+require 'rack/cloudflare_jwt'


### PR DESCRIPTION
As titled, this little helper file will allow bundler user no longer need to explictly `require 'rack/cloudflare_jwt'`