### PR TITLE
[STUDIO-1655] Allow to use own CloudFlare AUDs for paths

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,11 @@
 # See example at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 require:
   - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.6
+  NewCops: enable
 
 # Align the elements of a hash literal if they span more than one line.
 Layout/HashAlignment:
@@ -35,44 +37,11 @@ Layout/HashAlignment:
 Style/Documentation:
   Enabled: false
 
-Layout/BeginEndAlignment:
-  Enabled: true
-
 Layout/EmptyLines:
   Enabled: false
 
 Layout/LineLength:
   Max: 150
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/MissingSuper:
-  Enabled: true
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/UnreachableLoop:
-  Enabled: true
 
 Metrics/AbcSize:
   Enabled: true
@@ -86,6 +55,10 @@ Metrics/BlockLength:
   Enabled:       false
   CountComments: false
 
+Metrics/CyclomaticComplexity:
+  Enabled: true
+  Max:     10
+
 Metrics/MethodLength:
   Enabled:       true
   CountComments: false
@@ -97,45 +70,8 @@ Naming/MethodParameterName:
 Naming/BlockParameterName:
   MinNameLength: 2
 
-Lint/ConstantDefinitionInBlock:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/DuplicateRequire:
-  Enabled: true
-
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Lint/EmptyFile:
-  Enabled: true
-
-Lint/IdentityComparison:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: false
-
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: true
-
-Lint/UselessMethodDefinition:
-  Enabled: true
-
-Lint/UselessTimes:
-  Enabled: true
-
-Layout/BeginEndAlignment:
-  Enabled: true
-
-#Checks method call operators to not have spaces around them.
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
 
 Layout/SpaceInsideParens:
   Enabled: false
@@ -143,126 +79,21 @@ Layout/SpaceInsideParens:
 Layout/SpaceBeforeFirstArg:
   Enabled: false
 
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Performance/AncestorsInclude:
-  Enabled: true
-
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-
-Performance/RedundantSortBlock:
-  Enabled: true
-
-Performance/RedundantStringChars:
-  Enabled: true
-
-Performance/ReverseFirst:
-  Enabled: true
-
-Performance/SortReverse:
-  Enabled: true
-
-Performance/Squeeze:
-  Enabled: true
-
-Performance/StringInclude:
-  Enabled: true
-
 Style/AccessModifierDeclarations:
   Enabled: false
 
-Style/AccessorGrouping:
-  Enabled: true
-
-Style/ArrayCoercion:
-  Enabled: true
-
-Style/BisectedAttrAccessor:
-  Enabled: true
-
 Style/BlockDelimiters:
   Enabled: false
-
-Style/CaseLikeIf:
-  Enabled: true
 
 Style/ClassAndModuleChildren:
   Enabled:       true
   EnforcedStyle: compact
 
-Style/CombinableLoops:
-  Enabled: true
-
-Style/ExplicitBlockArgument:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: false
-
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Style/GlobalStdStream:
-  Enabled: true
-
-Style/HashAsLastArrayItem:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashLikeCase:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/KeywordParametersOrder:
-  Enabled: true
-
-Style/OptionalBooleanParameter:
-  Enabled: true
-
-Style/RedundantAssignment:
-  Enabled: true
-
-Style/RedundantSelfAssignment:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-
 Style/RedundantReturn:
   Enabled: false
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: false
-
-Style/SingleArgumentDig:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
-Style/SoleNestedConditional:
-  Enabled: true
-
-Style/StringConcatenation:
-  Enabled: true
 
 Style/TrailingCommaInArguments:
   Enabled:                   true
@@ -283,3 +114,9 @@ Style/AndOr:
 # We use %w[ ], not %w( ) because the former looks like an array
 Style/PercentLiteralDelimiters:
   Enabled: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10

--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ $ gem install rack-cloudflare-jwt
 
 ## Usage
 
-`Rack::CloudflareJwt::Auth` accepts several configuration options. All options are passed in a single Ruby Hash:
+`Rack::CloudflareJwt::Auth` accepts configuration options. All options are passed in a single Ruby `Hash<String, String>`. E.g. `{ '/admin' => 'aud-1', '/manager' => 'aud-2' }`.
 
-* `policy_aud` : required : `String` : A Application Audience (AUD) Tag.
+* `Hash` key : `String` : A path string representing paths that should be checked for the presence of a valid JWT token. Includes sub-paths as of specified path as well (e.g. `/docs` includes `/docs/some/thing.html` also). Each path should start with a `/`. If a path not matches the current request path this entire middleware is skipped and no authentication or verification of tokens takes place.
 
-* `include_paths` : optional : Array : An Array of path strings representing paths that should be checked for the presence of a valid JWT token. Includes sub-paths as of specified paths as well (e.g. `%w(/docs)` includes `/docs/some/thing.html` also). Each path should start with a `/`. If a path not matches the current request path this entire middleware is skipped and no authentication or verification of tokens takes place.
+* `Hash` value : `String` : A Application Audience (AUD) Tag.
+
 
 ### Rails
 
 ```ruby
-require 'rack/cloudflare_jwt'
-Rails.application.config.middleware.use Rack::CloudflareJwt::Auth, policy_aud: 'xxx.yyy.zzz', include_paths: %w[/foo]
+Rails.application.config.middleware.use Rack::CloudflareJwt::Auth, '/my-path' => 'xxx.yyy.zzz'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ gem install rack-cloudflare-jwt
 
 `Rack::CloudflareJwt::Auth` accepts configuration options. All options are passed in a single Ruby `Hash<String, String>`. E.g. `{ '/admin' => 'aud-1', '/manager' => 'aud-2' }`.
 
-* `Hash` key : `String` : A path string representing paths that should be checked for the presence of a valid JWT token. Includes sub-paths as of specified path as well (e.g. `/docs` includes `/docs/some/thing.html` also). Each path should start with a `/`. If a path not matches the current request path this entire middleware is skipped and no authentication or verification of tokens takes place.
+* `Hash` key : `String` : A path string representing paths that should be checked for the presence of a valid JWT token. Includes sub-paths as of specified path as well (e.g. `/docs` includes `/docs/some/thing.html` also). Each path should start with a `/`. If a path doesn't matches the current request path this entire middleware is skipped and no authentication or verification of tokens takes place.
 
 * `Hash` value : `String` : A Application Audience (AUD) Tag.
 

--- a/rack-cloudflare-jwt.gemspec
+++ b/rack-cloudflare-jwt.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake',                '>= 12.0.0'
   spec.add_development_dependency 'rspec',               '>= 3.8.0'
   spec.add_development_dependency 'rubocop-performance', '>= 1.0.0'
+  spec.add_development_dependency 'rubocop-rspec',       '>= 2.0.0'
   spec.add_development_dependency 'simplecov',           '>= 0.16.0'
   spec.add_development_dependency 'webmock',             '>= 3.8.0'
 

--- a/spec/rack/cloudflare_jwt/auth_spec.rb
+++ b/spec/rack/cloudflare_jwt/auth_spec.rb
@@ -11,84 +11,75 @@ describe Rack::CloudflareJwt::Auth do
   end
 
   let(:app) do
-    described_class.new(inner_app, policy_aud: policy_aud)
+    described_class.new(inner_app, '/' => policy_aud)
   end
 
-  describe 'initialization of' do
-    describe 'policy_aud' do
-      describe 'with only policy_aud: arg provided' do
-        let(:app) { described_class.new(inner_app, policy_aud: policy_aud) }
-        it 'succeeds' do
-          expect(app.policy_aud).to eq(policy_aud)
-        end
-      end
+  describe 'initialization of #policies' do
+    describe 'with policy auds: arg provided' do
+      let(:args) { { '/admin' => 'aud-1', '/manager' => 'aud-2' } }
+      let(:app) { described_class.new(inner_app, args) }
 
-      describe 'with no policy_aud: arg provided' do
-        it 'raises ArgumentError' do
-          expect { described_class.new(inner_app, {}) }.to raise_error(ArgumentError)
-        end
-      end
-
-      describe 'with policy_aud: arg of invalid type' do
-        it 'raises ArgumentError' do
-          expect { described_class.new(inner_app, policy_aud: []) }.to raise_error(ArgumentError)
-        end
-      end
-
-      describe 'with nil policy_aud: arg provided' do
-        it 'raises ArgumentError' do
-          expect { described_class.new(inner_app, policy_aud: nil) }.to raise_error(ArgumentError)
-        end
-      end
-
-      describe 'with empty policy_aud: arg provided' do
-        it 'raises ArgumentError' do
-          expect { described_class.new(inner_app, policy_aud: '') }.to raise_error(ArgumentError)
-        end
-      end
-
-      describe 'with spaces policy_aud: arg provided' do
-        it 'raises ArgumentError' do
-          expect { described_class.new(inner_app, policy_aud: '     ') }.to raise_error(ArgumentError)
-        end
+      it 'succeeds' do
+        expect(app.policies).to eq args
       end
     end
 
-    describe 'include_paths' do
-      describe 'when a type other than Array provided' do
-        it 'raises an exception' do
-          args = { policy_aud: policy_aud, include_paths: {} }
-          expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
-        end
+    describe 'with no policy auds: arg provided' do
+      it 'raises ArgumentError' do
+        expect { described_class.new(inner_app, {}) }.to raise_error(ArgumentError)
       end
+    end
 
-      describe 'when Array contains non-String elements' do
-        it 'raises an exception' do
-          args = { policy_aud: policy_aud, include_paths: ['/foo', nil, '/bar'] }
-          expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
-        end
+    describe 'with policy auds: arg of invalid type' do
+      it 'raises ArgumentError' do
+        expect { described_class.new(inner_app, '/' => []) }.to raise_error(ArgumentError)
       end
+    end
 
-      describe 'when Array contains empty String elements' do
-        it 'raises an exception' do
-          args = { policy_aud: policy_aud, include_paths: ['/foo', '', '/bar'] }
-          expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
-        end
+    describe 'with nil policy auds: arg provided' do
+      it 'raises ArgumentError' do
+        expect { described_class.new(inner_app, '/' => nil) }.to raise_error(ArgumentError)
       end
+    end
 
-      describe 'when Array contains elements that do not start with a /' do
-        it 'raises an exception' do
-          args = { policy_aud: policy_aud, include_paths: ['/foo', 'bar', '/baz'] }
-          expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
-        end
+    describe 'with empty policy auds: arg provided' do
+      it 'raises ArgumentError' do
+        expect { described_class.new(inner_app, '/' => '') }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe 'with spaces policy auds: arg provided' do
+      it 'raises ArgumentError' do
+        expect { described_class.new(inner_app, '/' => '     ') }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe 'when Hash keys contains non-String elements' do
+      it 'raises an exception' do
+        args = { %w[/foo /bar] => policy_aud }
+        expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe 'when Hash keys contains empty String elements' do
+      it 'raises an exception' do
+        args = { '' => policy_aud }
+        expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe 'when Hash keys contains elements that do not start with a /' do
+      it 'raises an exception' do
+        args = { 'bar' => policy_aud }
+        expect { described_class.new(inner_app, args) }.to raise_error(ArgumentError)
       end
     end
   end
 
   describe '#verify_token' do
     let(:public_keys) { [OpenSSL::PKey::RSA.new(2048), OpenSSL::PKey::RSA.new(2048)] }
-    let(:env)         { { described_class::HEADER_NAME => 'JWT token' } }
-    let(:logger)      { double(debug: true, info: true) }
+    let(:env)         { { described_class::HEADER_NAME => 'JWT token', described_class::PATH_INFO => '/admin' } }
+    let(:logger)      { double(:logger, debug: true, info: true) } # rubocop:disable RSpec/VerifiedDoubles
 
     before do
       allow(app).to receive(:logger) { logger }
@@ -97,17 +88,17 @@ describe Rack::CloudflareJwt::Auth do
 
     context 'with valid token' do
       before do
-        expect(app).to receive(:decode_token).and_raise(described_class::DecodeTokenError, 'foo')
-        expect(app).to receive(:decode_token).and_return([{}, {}])
+        expect(app).to receive(:decode_token).and_raise(described_class::DecodeTokenError, 'foo') # rubocop:disable RSpec/ExpectInHook
+        expect(app).to receive(:decode_token).and_return([{}, {}]) # rubocop:disable RSpec/ExpectInHook, RSpec/StubbedMock
       end
-
-      it { expect(inner_app).to receive(:call) }
-      it { expect(logger).to receive(:info).with('foo') }
-      it { expect(app).to_not receive(:return_error) }
 
       after do
         app.send(:verify_token, env)
       end
+
+      it { expect(inner_app).to receive(:call) }
+      it { expect(logger).to receive(:info).with('foo') }
+      it { expect(app).not_to receive(:return_error) }
     end
 
     context 'with invalid token' do
@@ -115,20 +106,20 @@ describe Rack::CloudflareJwt::Auth do
         allow(app).to receive(:decode_token).and_raise(described_class::DecodeTokenError, 'foo').twice
       end
 
-      it { expect(inner_app).to_not receive(:call) }
-      it { expect(logger).to receive(:info).with('foo').twice }
-      it { expect(app).to receive(:return_error) }
-
       after do
         app.send(:verify_token, env)
       end
+
+      it { expect(inner_app).not_to receive(:call) }
+      it { expect(logger).to receive(:info).with('foo').twice }
+      it { expect(app).to receive(:return_error) }
     end
   end
 
   describe '#decode_token' do
     it 'returns a token' do
-      allow(Rack::JWT::Token).to receive(:decode) { [{}, {}] }
-      expect(app.send(:decode_token, 'foo', 'bar')).to eq [{}, {}]
+      allow(Rack::JWT::Token).to receive(:decode).and_return([{}, {}])
+      expect(app.send(:decode_token, 'foo', 'bar', 'cf-aud')).to eq [{}, {}]
     end
 
     [
@@ -145,7 +136,7 @@ describe Rack::CloudflareJwt::Auth do
     ].each do |error_class|
       it "raises an error at #{error_class} error" do
         allow(Rack::JWT::Token).to receive(:decode).and_raise(error_class)
-        expect { app.send(:decode_token, 'foo', 'bar') }.to raise_error(described_class::DecodeTokenError)
+        expect { app.send(:decode_token, 'foo', 'bar', 'cf-aud') }.to raise_error(described_class::DecodeTokenError)
       end
     end
   end
@@ -155,11 +146,8 @@ describe Rack::CloudflareJwt::Auth do
 
     before do
       allow(app).to receive(:cache) { cache }
-      allow(cache).to receive(:fetch) do |&block|
-        block.call
-      end
-
-      stub_request(:get, /#{described_class::CERTS_PATH}/).to_return(status: 200, body: <<-JSON)
+      allow(cache).to receive(:fetch).and_yield(->(&block) { block.call })
+      stub_request(:get, /#{described_class::CERTS_PATH}/o).to_return(status: 200, body: <<-JSON)
         {"keys":[{"kid":"b18283ffda890c840aa529674e75f9e59514409e5e55e2d0bad5795858e66228","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"vy-V_OfLu6T57U-xRzSo9mHzgSwa6-z_qQFquwxp0SlqCGr04Wd2AO2u9pUA0MNNbp_GtIarbBvMqwMIkjIF-YkUS7Nme4H64nryTVPEnvMsOO1U0BNs1FxMhhBfy2f3gI6wfXfaRGiJuadZjCQVBjXor9sjhWAeU3ONGaOxUfgK-paB5VaLwcJh-RouG2GZvRI96Be23s0lmp0c-jkfY2yxmEhkwp5bvplEDPQL13mdigt1epUyAYTGYR22c06iViiZMQSPrsivfQXay8vCGQWWTEf5gS6DPsUkrc-7eFjYO_2nj7fJVf4IrFv54ZiFCXx0-UgSWtxH69hJkxdzpQ"},{"kid":"ac2790adb86610b4aac3b5b2512f755dd817af640afbcec7763635c701c4f566","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"1bfNhQpbF5rC-9WeGJUXDAEwKS5BFaKBJI2RXqcabhTF5qErClzT147DOK5AXKarMV-zcLmOkK8qZklmxtJhcJ_MfH3c7rtGY6TqTvwU9SqBFq6YBDfZEVaxY-78xzWzYefilywE8cpzgYZXC56iRe0n-bCXu8HQD_p3CXExjRqS--Pmr1-y27XxG8QH7WR7ETr9gnfTqAvMPw-B3C7FxVcNTqorycpiow5Jiqr9SxyxZgZ79lwQ5WiQTeB0WLg7XfSK3kEqZ63NsAO03N6AQT-QQQprMYg8oZ85aOlbEh8TahRZXeZiJ2jbEFDJoyuqCwroA1kgzaLKjSpjeOzXHw"}],"public_cert":{"kid":"b18283ffda890c840aa529674e75f9e59514409e5e55e2d0bad5795858e66228","cert":"-----BEGIN CERTIFICATE-----\\nMIIDUTCCAjmgAwIBAgIRAJrBOaRWSa+JYrHKcIYyKu0wDQYJKoZIhvcNAQELBQAw\\nYjELMAkGA1UEBhMCVVMxDjAMBgNVBAgTBVRleGFzMQ8wDQYDVQQHEwZBdXN0aW4x\\nEzARBgNVBAoTCkNsb3VkZmxhcmUxHTAbBgNVBAMTFGNsb3VkZmxhcmVhY2Nlc3Mu\\nY29tMB4XDTIwMDIyNDE2MTEwOFoXDTIwMDQyNDE2MTEwOFowYjELMAkGA1UEBhMC\\nVVMxDjAMBgNVBAgTBVRleGFzMQ8wDQYDVQQHEwZBdXN0aW4xEzARBgNVBAoTCkNs\\nb3VkZmxhcmUxHTAbBgNVBAMTFGNsb3VkZmxhcmVhY2Nlc3MuY29tMIIBIjANBgkq\\nhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvy+V/OfLu6T57U+xRzSo9mHzgSwa6+z/\\nqQFquwxp0SlqCGr04Wd2AO2u9pUA0MNNbp/GtIarbBvMqwMIkjIF+YkUS7Nme4H6\\n4nryTVPEnvMsOO1U0BNs1FxMhhBfy2f3gI6wfXfaRGiJuadZjCQVBjXor9sjhWAe\\nU3ONGaOxUfgK+paB5VaLwcJh+RouG2GZvRI96Be23s0lmp0c+jkfY2yxmEhkwp5b\\nvplEDPQL13mdigt1epUyAYTGYR22c06iViiZMQSPrsivfQXay8vCGQWWTEf5gS6D\\nPsUkrc+7eFjYO/2nj7fJVf4IrFv54ZiFCXx0+UgSWtxH69hJkxdzpQIDAQABowIw\\nADANBgkqhkiG9w0BAQsFAAOCAQEAtoSWQEbcb2EhQOLaxXA+Dupfsy+cZNsjKhq8\\nlOex8RZvMsj69FPofiJTxAR3RTwQiWDTmx3kUvBbIr2IrKtUllD8/jO/GzAyd93c\\nrzZcLk3CNPNzKkbRFtM8qy4jBcupKsS2KHzDZ5uaKIad4i/s/9ld0r0fvjS3iiyJ\\nJDxwQXvzvf1fNOdb2na+tdKa/BBxz8blCybrICqH2dR2jw6YawUbGNU7zWVjR5Mc\\n2/3Q85l8qluZKARDUUL1uG3aeiIWhzuVvxYwisUBXIBvVqXB2V7xIiRAfIYscT4s\\ngktcHT8x59pgl1WI2UHBfJmZoecMrZXVZ5zxVOA9EVg88L/hSQ==\\n-----END CERTIFICATE-----\\n"}}
       JSON
     end


### PR DESCRIPTION
## Allow to use own CloudFlare AUDs for paths

[Jira Tech task](https://shuttlerock.atlassian.net/browse/STUDIO-1655)

We should allow to use own CloudFlare AUDs for paths. E.g.:

```
    config.middleware.use(
      Rack::CloudflareJwt::Auth,
      '/admin' => Rails.application.secrets.cloudflare_jwt.fetch(:admin_policy_aud),
      '/rails' => Rails.application.secrets.cloudflare_jwt.fetch(:rails_policy_aud),
    )
```

## Deployment Notes

No
